### PR TITLE
Creacion de gitignore para .log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignorar logs
+logs/**/*.log


### PR DESCRIPTION
Ignorar todos los archivos .log del repositorio para que no se suban al controlador de versiones (nuestro repositorio de github, pero en local siguen estando), necesario porque con cada ejecución de nuestra aplicación que estamos creando, se pueden crear logs que son irrelevantes subirlo, incluso se podría exponer información critica al repositorio